### PR TITLE
Fix/Looky-3853: handle invalid CropRectangle

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
+++ b/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
@@ -243,6 +243,15 @@ public class ImageEditorModule extends ReactContextBaseJavaModule {
         int height,
         Promise promise) {
       super(context);
+      if (x < 0) {
+        Log.d("ImageEditor", String.format("Invalid crop rectangle x (%d), replacing with 0", x));
+        x = 0;
+      }
+      if (y < 0) {
+        Log.d("ImageEditor", String.format("Invalid crop rectangle y (%d), replacing with 0", y));
+        y = 0;
+      }
+
       if (x < 0 || y < 0 || width <= 0 || height <= 0) {
         throw new JSApplicationIllegalArgumentException(String.format(
             "Invalid crop rectangle: [%d, %d, %d, %d]", x, y, width, height));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/image-editor",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "React Native Image Editing native modules for iOS & Android",
   "main": "lib/ImageEditor.ts",
   "typings": "typings/index.d.ts",


### PR DESCRIPTION
# Merge with: 

https://oneclicklife.youtrack.cloud/issue/Looky-3853/Android-Krash-pri-reposte-iz-mozajki